### PR TITLE
Reorganize configuration thanks to config.include

### DIFF
--- a/packassembler/__init__.py
+++ b/packassembler/__init__.py
@@ -2,8 +2,7 @@ from pyramid.config import Configurator
 
 
 def main(global_config, **settings):
-    config = Configurator(settings=settings,
-                          root_factory='packassembler.security.Root')
+    config = Configurator(settings=settings)
     config.include(__name__)
     return config.make_wsgi_app()
 

--- a/packassembler/__init__.py
+++ b/packassembler/__init__.py
@@ -1,127 +1,15 @@
 from pyramid.config import Configurator
-from pyramid.authentication import AuthTktAuthenticationPolicy
-from pyramid.authorization import ACLAuthorizationPolicy
-
-from .security import find_group
-
-
-def setup_auth(config):
-    authn_policy = AuthTktAuthenticationPolicy('authtktpolicysek', callback=find_group, hashalg='sha512')
-    authz_policy = ACLAuthorizationPolicy()
-    config.set_authorization_policy(authz_policy)
-    config.set_authentication_policy(authn_policy)
-
-
-def setup_tweens(config):
-    config.add_tween('packassembler.tweens.exception_tween_factory')
-
-
-def setup_routes(config):
-    # General
-    config.add_route('home', '/')
-    config.add_route('faq', '/faq')
-    config.add_route('gettingstarted', '/gettingstarted')
-    config.add_route('success', '/success')
-    config.add_route('error', '/error/{type}')
-
-    # User
-    ## Listing
-    config.add_route('userlist', '/users')
-    ## Signup Process
-    config.add_route('signup', '/users/signup')
-    config.add_route('activate', '/users/{id}/activate/{key}')
-    ## Login/Logout
-    config.add_route('login', '/users/login')
-    config.add_route('logout', '/users/logout')
-    ## Password Reset
-    config.add_route('sendreset', '/users/reset')
-    config.add_route('reset', '/users/{id}/reset/{key}')
-    ## RUD
-    config.add_route('edituser', '/users/{id}/edit')
-    config.add_route('deleteuser', '/users/{id}/delete')
-    config.add_route('profile', '/users/{id}')
-    ## Email
-    config.add_route('emailuser', '/users/{id}/email')
-
-    # Mods
-    ## Listing
-    config.add_route('modlist', '/mods')
-    config.add_route('qmlist', '/mods.json')
-    ## Spcial Actions
-    config.add_route('adoptmod', '/mods/{id}/adopt')
-    config.add_route('disownmod', '/mods/{id}/disown')
-    config.add_route('flagmod', '/mods/{id}/flag')
-    config.add_route('moveversion', '/mods/{id}/moveversion/{index}/{shift}')
-    config.add_route('quickmod', '/mods/{id}.json')
-    ## Details
-    config.add_route('editmodbanner', '/mods/{id}/banner/edit')
-    ## CRUD
-    config.add_route('addmod', '/mods/add')
-    config.add_route('editmod', '/mods/{id}/edit')
-    config.add_route('deletemod', '/mods/{id}/delete')
-    config.add_route('viewmod', '/mods/{id}')
-
-    # Mod versions
-    config.add_route('addversion', '/mods/{id}/versions/add')
-    config.add_route('quickadd', '/mods/{id}/versions/quickadd')
-    config.add_route('editversion', '/mods/versions/{id}/edit')
-    config.add_route('downloadversion', '/mods/versions/{id}/download')
-    config.add_route('deleteversion', '/mods/versions/{id}/delete')
-    config.add_route('versiondetails', '/mods/versions/{id}')
-    config.add_route('qmversions', '/mods/{id}/versions.json')
-
-    # Packs
-    ## Listing
-    config.add_route('packlist', '/packs')
-    ## API
-    config.add_route('mcuxmlpack', '/packs/{id}/mcuxml')
-    config.add_route('downloadpack', '/packs/{id}/download')
-    config.add_route('forgeversions', '/packs/forgeversions')
-    ## Details
-    config.add_route('editpackbanner', '/packs/{id}/banner/edit')
-    ## CRUD
-    config.add_route('addpack', '/packs/add')
-    config.add_route('clonepack', 'packs/{id}/clone')
-    config.add_route('editpack', '/packs/{id}/edit')
-    config.add_route('deletepack', '/packs/{id}/delete')
-    config.add_route('viewpack', '/packs/{id}')
-
-    ## Mods
-    config.add_route('addpackmod', '/packs/{id}/addmod')
-    config.add_route('removepackmod', '/packs/{id}/removemod')
-
-    ## Base Packs
-    config.add_route('addbasepack', '/packs/{id}/addbase')
-    config.add_route('removebasepack', '/packs/{id}/removebase')
-
-    ## Builds
-    config.add_route('addbuild', '/packs/{id}/builds/add')
-    config.add_route('deletebuild', '/packs/builds/{id}/delete')
-    config.add_route('downloadbuild', '/packs/builds/{id}')
-    config.add_route('mcuxml', '/packs/builds/{id}/mcuxml')
-    config.add_route('paq', '/packs/builds/{id}/paq')
-
-    # Servers
-    ## Listing
-    config.add_route('serverlist', '/servers')
-    ## API
-    config.add_route('mcuxmlserver', '/servers/{id}/mcuxml')
-    ## Details
-    config.add_route('editserverbanner', '/servers/{id}/banner/edit')
-    ## CRUD
-    config.add_route('addserver', '/servers/add')
-    config.add_route('editserver', '/servers/{id}/edit')
-    config.add_route('deleteserver', '/servers/{id}/delete')
-    config.add_route('viewserver', '/servers/{id}')
-
-    config.add_static_view('static', 'static', cache_max_age=3600)
-    config.scan()
 
 
 def main(global_config, **settings):
-    config = Configurator(settings=settings, root_factory='packassembler.security.Root')
-    setup_auth(config)
-    setup_tweens(config)
-    setup_routes(config)
-
+    config = Configurator(settings=settings,
+                          root_factory='packassembler.security.Root')
+    config.include(__name__)
     return config.make_wsgi_app()
+
+
+def includeme(config):
+    config.include('.security')
+    config.include('.tweens')
+    config.include('.routes')
+    config.include('.views')

--- a/packassembler/routes.py
+++ b/packassembler/routes.py
@@ -1,0 +1,100 @@
+
+def includeme(config):
+    # General
+    config.add_route('home', '/')
+    config.add_route('faq', '/faq')
+    config.add_route('gettingstarted', '/gettingstarted')
+    config.add_route('success', '/success')
+    config.add_route('error', '/error/{type}')
+
+    # User
+    ## Listing
+    config.add_route('userlist', '/users')
+    ## Signup Process
+    config.add_route('signup', '/users/signup')
+    config.add_route('activate', '/users/{id}/activate/{key}')
+    ## Login/Logout
+    config.add_route('login', '/users/login')
+    config.add_route('logout', '/users/logout')
+    ## Password Reset
+    config.add_route('sendreset', '/users/reset')
+    config.add_route('reset', '/users/{id}/reset/{key}')
+    ## RUD
+    config.add_route('edituser', '/users/{id}/edit')
+    config.add_route('deleteuser', '/users/{id}/delete')
+    config.add_route('profile', '/users/{id}')
+    ## Email
+    config.add_route('emailuser', '/users/{id}/email')
+
+    # Mods
+    ## Listing
+    config.add_route('modlist', '/mods')
+    config.add_route('qmlist', '/mods.json')
+    ## Spcial Actions
+    config.add_route('adoptmod', '/mods/{id}/adopt')
+    config.add_route('disownmod', '/mods/{id}/disown')
+    config.add_route('flagmod', '/mods/{id}/flag')
+    config.add_route('moveversion', '/mods/{id}/moveversion/{index}/{shift}')
+    config.add_route('quickmod', '/mods/{id}.json')
+    ## Details
+    config.add_route('editmodbanner', '/mods/{id}/banner/edit')
+    ## CRUD
+    config.add_route('addmod', '/mods/add')
+    config.add_route('editmod', '/mods/{id}/edit')
+    config.add_route('deletemod', '/mods/{id}/delete')
+    config.add_route('viewmod', '/mods/{id}')
+
+    # Mod versions
+    config.add_route('addversion', '/mods/{id}/versions/add')
+    config.add_route('quickadd', '/mods/{id}/versions/quickadd')
+    config.add_route('editversion', '/mods/versions/{id}/edit')
+    config.add_route('downloadversion', '/mods/versions/{id}/download')
+    config.add_route('deleteversion', '/mods/versions/{id}/delete')
+    config.add_route('versiondetails', '/mods/versions/{id}')
+    config.add_route('qmversions', '/mods/{id}/versions.json')
+
+    # Packs
+    ## Listing
+    config.add_route('packlist', '/packs')
+    ## API
+    config.add_route('mcuxmlpack', '/packs/{id}/mcuxml')
+    config.add_route('downloadpack', '/packs/{id}/download')
+    config.add_route('forgeversions', '/packs/forgeversions')
+    ## Details
+    config.add_route('editpackbanner', '/packs/{id}/banner/edit')
+    ## CRUD
+    config.add_route('addpack', '/packs/add')
+    config.add_route('clonepack', 'packs/{id}/clone')
+    config.add_route('editpack', '/packs/{id}/edit')
+    config.add_route('deletepack', '/packs/{id}/delete')
+    config.add_route('viewpack', '/packs/{id}')
+
+    ## Mods
+    config.add_route('addpackmod', '/packs/{id}/addmod')
+    config.add_route('removepackmod', '/packs/{id}/removemod')
+
+    ## Base Packs
+    config.add_route('addbasepack', '/packs/{id}/addbase')
+    config.add_route('removebasepack', '/packs/{id}/removebase')
+
+    ## Builds
+    config.add_route('addbuild', '/packs/{id}/builds/add')
+    config.add_route('deletebuild', '/packs/builds/{id}/delete')
+    config.add_route('downloadbuild', '/packs/builds/{id}')
+    config.add_route('mcuxml', '/packs/builds/{id}/mcuxml')
+    config.add_route('paq', '/packs/builds/{id}/paq')
+
+    # Servers
+    ## Listing
+    config.add_route('serverlist', '/servers')
+    ## API
+    config.add_route('mcuxmlserver', '/servers/{id}/mcuxml')
+    ## Details
+    config.add_route('editserverbanner', '/servers/{id}/banner/edit')
+    ## CRUD
+    config.add_route('addserver', '/servers/add')
+    config.add_route('editserver', '/servers/{id}/edit')
+    config.add_route('deleteserver', '/servers/{id}/delete')
+    config.add_route('viewserver', '/servers/{id}')
+
+    config.add_static_view('static', 'static', cache_max_age=3600)

--- a/packassembler/security.py
+++ b/packassembler/security.py
@@ -11,6 +11,7 @@ hpass = lambda password: hmac.new(password.encode()).digest()
 
 
 def includeme(config):
+    config.set_root_factory('packassembler.security.Root')
     authn_policy = AuthTktAuthenticationPolicy('authtktpolicysek',
                                                callback=find_group,
                                                hashalg='sha512')

--- a/packassembler/security.py
+++ b/packassembler/security.py
@@ -1,3 +1,5 @@
+from pyramid.authentication import AuthTktAuthenticationPolicy
+from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.security import Allow, Everyone
 from mongoengine import connect
 from .schema import User
@@ -6,6 +8,15 @@ import hmac
 
 
 hpass = lambda password: hmac.new(password.encode()).digest()
+
+
+def includeme(config):
+    authn_policy = AuthTktAuthenticationPolicy('authtktpolicysek',
+                                               callback=find_group,
+                                               hashalg='sha512')
+    authz_policy = ACLAuthorizationPolicy()
+    config.set_authorization_policy(authz_policy)
+    config.set_authentication_policy(authn_policy)
 
 
 def find_group(userid, request):

--- a/packassembler/tweens.py
+++ b/packassembler/tweens.py
@@ -3,6 +3,10 @@ from packassembler.views.common import NoPermission
 from .schema import DoesNotExist
 
 
+def includeme(config):
+    config.add_tween(exception_tween_factory)
+
+
 def exception_tween_factory(handler, registry):
     def exception_tween(request):
         try:

--- a/packassembler/views/__init__.py
+++ b/packassembler/views/__init__.py
@@ -1,0 +1,3 @@
+
+def includeme(config):
+    config.scan(__name__)


### PR DESCRIPTION
Some help to re-organize configuration after a chat on #pyramid:
Here is the transcript:

<pre>
10:43:04 PM stephenmac7: My config is not out of control at all
10:43:19 PM phira: *grins*
10:43:29 PM stephenmac7: ...I don't think. https://github.com/PackAssembler/PackAssembler/blob/master/packassembler/__init__.py
10:59:55 PM hadr: stephenmac7: your config is clean but, you can break apart your configuration to sub modules using config.include
11:03:01 PM hadr: stephenmac7: —> so you can get that: https://github.com/hadrien/PackAssembler/blob/master/packassembler/__init__.py
11:03:54 PM stephenmac7: hadr: Ah, I see. That does look nicer
11:04:46 PM hadr: stephenmac7: another tip: I always put includeme function or main on top of includable or main files
11:04:53 PM hadr: so that when you open it
11:05:01 PM stephenmac7: Yes, that would make it easier to identify what it does
11:05:06 PM hadr: exactly
11:05:29 PM stephenmac7: Would it be possible for me to use what you've changed there?
11:05:41 PM hadr: sure
11:05:47 PM hadr: lemme open a pull request
11:05:54 PM stephenmac7: Okay, thanks.
11:07:00 PM hadr: stephenmac7: https://github.com/PackAssembler/PackAssembler/pull/30
11:09:19 PM stephenmac7: hadr: It works, thanks.
11:09:57 PM hadr: stephenmac7: cool! you're welcome!
</pre>
